### PR TITLE
[bugfix] 중복 가입 방지

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -60,6 +60,7 @@ const RAW_RUNTIME_STATE =
           ["react-query", "virtual:150264159473de5ad3d609c3d588131dba04597fc50d2bdbfb116498641e1e6ef86fea22e55cfcdd57a3c11c269416a4e51b17e65777452f1b56eb2f4e5c79b6#npm:3.39.3"],\
           ["react-router-dom", "virtual:150264159473de5ad3d609c3d588131dba04597fc50d2bdbfb116498641e1e6ef86fea22e55cfcdd57a3c11c269416a4e51b17e65777452f1b56eb2f4e5c79b6#npm:6.27.0"],\
           ["react-scripts", "virtual:150264159473de5ad3d609c3d588131dba04597fc50d2bdbfb116498641e1e6ef86fea22e55cfcdd57a3c11c269416a4e51b17e65777452f1b56eb2f4e5c79b6#npm:5.0.1"],\
+          ["recoil", "virtual:150264159473de5ad3d609c3d588131dba04597fc50d2bdbfb116498641e1e6ef86fea22e55cfcdd57a3c11c269416a4e51b17e65777452f1b56eb2f4e5c79b6#npm:0.7.7"],\
           ["swiper", "npm:11.1.14"],\
           ["typescript", "patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"],\
           ["web-vitals", "npm:2.1.4"]\
@@ -12025,6 +12026,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["hamt_plus", [\
+      ["npm:1.0.2", {\
+        "packageLocation": "../../../AppData/Local/Yarn/Berry/cache/hamt_plus-npm-1.0.2-67a52ee1df-10c0.zip/node_modules/hamt_plus/",\
+        "packageDependencies": [\
+          ["hamt_plus", "npm:1.0.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["handle-thing", [\
       ["npm:2.0.1", {\
         "packageLocation": "../../../AppData/Local/Yarn/Berry/cache/handle-thing-npm-2.0.1-084baca59e-10c0.zip/node_modules/handle-thing/",\
@@ -15899,6 +15909,7 @@ const RAW_RUNTIME_STATE =
           ["react-query", "virtual:150264159473de5ad3d609c3d588131dba04597fc50d2bdbfb116498641e1e6ef86fea22e55cfcdd57a3c11c269416a4e51b17e65777452f1b56eb2f4e5c79b6#npm:3.39.3"],\
           ["react-router-dom", "virtual:150264159473de5ad3d609c3d588131dba04597fc50d2bdbfb116498641e1e6ef86fea22e55cfcdd57a3c11c269416a4e51b17e65777452f1b56eb2f4e5c79b6#npm:6.27.0"],\
           ["react-scripts", "virtual:150264159473de5ad3d609c3d588131dba04597fc50d2bdbfb116498641e1e6ef86fea22e55cfcdd57a3c11c269416a4e51b17e65777452f1b56eb2f4e5c79b6#npm:5.0.1"],\
+          ["recoil", "virtual:150264159473de5ad3d609c3d588131dba04597fc50d2bdbfb116498641e1e6ef86fea22e55cfcdd57a3c11c269416a4e51b17e65777452f1b56eb2f4e5c79b6#npm:0.7.7"],\
           ["swiper", "npm:11.1.14"],\
           ["typescript", "patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"],\
           ["web-vitals", "npm:2.1.4"]\
@@ -18463,6 +18474,37 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["readdirp", "npm:3.6.0"],\
           ["picomatch", "npm:2.3.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["recoil", [\
+      ["npm:0.7.7", {\
+        "packageLocation": "../../../AppData/Local/Yarn/Berry/cache/recoil-npm-0.7.7-4452f58b67-10c0.zip/node_modules/recoil/",\
+        "packageDependencies": [\
+          ["recoil", "npm:0.7.7"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:150264159473de5ad3d609c3d588131dba04597fc50d2bdbfb116498641e1e6ef86fea22e55cfcdd57a3c11c269416a4e51b17e65777452f1b56eb2f4e5c79b6#npm:0.7.7", {\
+        "packageLocation": "./.yarn/__virtual__/recoil-virtual-f78fa61e76/4/AppData/Local/Yarn/Berry/cache/recoil-npm-0.7.7-4452f58b67-10c0.zip/node_modules/recoil/",\
+        "packageDependencies": [\
+          ["recoil", "virtual:150264159473de5ad3d609c3d588131dba04597fc50d2bdbfb116498641e1e6ef86fea22e55cfcdd57a3c11c269416a4e51b17e65777452f1b56eb2f4e5c79b6#npm:0.7.7"],\
+          ["@types/react", "npm:18.3.11"],\
+          ["@types/react-dom", "npm:18.3.1"],\
+          ["@types/react-native", null],\
+          ["hamt_plus", "npm:1.0.2"],\
+          ["react", "npm:18.3.1"],\
+          ["react-dom", "virtual:150264159473de5ad3d609c3d588131dba04597fc50d2bdbfb116498641e1e6ef86fea22e55cfcdd57a3c11c269416a4e51b17e65777452f1b56eb2f4e5c79b6#npm:18.3.1"],\
+          ["react-native", null]\
+        ],\
+        "packagePeers": [\
+          "@types/react-dom",\
+          "@types/react-native",\
+          "@types/react",\
+          "react-dom",\
+          "react-native",\
+          "react"\
         ],\
         "linkType": "HARD"\
       }]\

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-query": "^3.39.3",
     "react-router-dom": "^6.27.0",
     "react-scripts": "5.0.1",
+    "recoil": "^0.7.7",
     "swiper": "^11.1.14",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import HotelPage from '@pages/Hotel'
 import TestPage from '@pages/Test'
 import MyPage from '@pages/My'
 import SigninPage from '@pages/Signin'
+import AuthGuard from '@components/auth/AuthGuard'
+import Navbar from '@shared/Navbar'
 
 import useLoadKakao from '@hooks/useLoadKakao'
 
@@ -13,13 +15,16 @@ function App() {
 
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<HotelList />} />
-        <Route path="/hotel/:id" element={<HotelPage />} />
-        <Route path="/my" element={<MyPage />} />
-        <Route path="/signin" element={<SigninPage />} />
-        <Route path="/test" element={<TestPage />} />
-      </Routes>
+      <AuthGuard>
+        <Navbar />
+        <Routes>
+          <Route path="/" element={<HotelList />} />
+          <Route path="/hotel/:id" element={<HotelPage />} />
+          <Route path="/my" element={<MyPage />} />
+          <Route path="/signin" element={<SigninPage />} />
+          <Route path="/test" element={<TestPage />} />
+        </Routes>
+      </AuthGuard>
     </BrowserRouter>
   )
 }

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+import { onAuthStateChanged } from 'firebase/auth'
+import { useSetRecoilState } from 'recoil'
+
+import { auth } from '@remote/firebase'
+import { userAtom } from '@store/atom/user'
+
+function AuthGuard({ children }: { children: React.ReactNode }) {
+  const [initialize, setInitialize] = useState(false)
+  //recoil에 state를 보관
+  const setUser = useSetRecoilState(userAtom)
+
+  // user state가 변경되었을때 호출되는 함수
+  onAuthStateChanged(auth, (user) => {
+    if (user == null) {
+      setUser(null)
+    } else {
+      setUser({
+        uid: user.uid,
+        email: user.email ?? '',
+        displayName: user.displayName ?? '',
+        photoUrl: user.photoURL ?? '',
+      })
+    }
+
+    setInitialize(true)
+  })
+
+  if (initialize === false) {
+    return null
+  }
+
+  return <>{children}</>
+}
+
+export default AuthGuard

--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -6,21 +6,30 @@ import Flex from '@shared/Flex'
 import Button from '@shared/Button'
 // import MyImage from '@shared/MyImage'
 import { colors } from '@styles/colorPalette'
+import useUser from '@hooks/auth/useUser'
 
 function Navbar() {
   const location = useLocation()
   const showSignButton =
     ['/signin', '/signup'].includes(location.pathname) === false
-  // @TODO
-  const user = null
 
+  const user = useUser()
+  console.log(user)
   const renderButton = useCallback(() => {
     if (user != null) {
       //TODO 클릭시 user 정보 페이지로 이동 기능 추가
       return (
         <Link to="/my">
-          {/* @TODO */}
-          <img src="" alt="" />
+          <img
+            src={
+              // user.photoUrl ??
+              'https://cdn1.iconfinder.com/data/icons/cute-emoji-smiles-with-gradient/83/Emoji_Emoticon_Happy_Laugh_Smile-512.png'
+            }
+            alt="유저의 이미지"
+            width={40}
+            height={40}
+            style={{ borderRadius: '100%' }}
+          />
         </Link>
       )
     }
@@ -38,7 +47,7 @@ function Navbar() {
 
   return (
     <Flex justify="space-between" align="center" css={navbarContainer}>
-      <Link to="/">홈</Link>
+      <Link to="/">Love Trip</Link>
       {renderButton()}
     </Flex>
   )

--- a/src/hooks/auth/useUser.ts
+++ b/src/hooks/auth/useUser.ts
@@ -1,0 +1,8 @@
+import { useRecoilValue } from 'recoil'
+import { userAtom } from '@store/atom/user'
+
+function useUser() {
+  return useRecoilValue(userAtom)
+}
+
+export default useUser

--- a/src/hooks/useLoadKakao.ts
+++ b/src/hooks/useLoadKakao.ts
@@ -16,7 +16,6 @@ function useLoadKakao() {
     script.onload = () => {
       if (!window.Kakao.isInitialized()) {
         window.Kakao.init(process.env.REACT_APP_KAKAO_API_KEY)
-        console.log(window.Kakao.Share)
       }
     }
   }, [])

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from 'react-query'
-import App from './App'
+import { RecoilRoot } from 'recoil'
 
+import App from './App'
 import { Global } from '@emotion/react'
 import globalStyles from '@styles/globalStyles'
 
@@ -18,8 +19,10 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
     <Global styles={globalStyles} />
-    <QueryClientProvider client={client}>
-      <App />
-    </QueryClientProvider>
+    <RecoilRoot>
+      <QueryClientProvider client={client}>
+        <App />
+      </QueryClientProvider>
+    </RecoilRoot>
   </React.StrictMode>,
 )

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,0 +1,6 @@
+export interface User {
+  uid: string
+  email: string
+  displayName?: string
+  photoUrl?: string
+}

--- a/src/store/atom/user.ts
+++ b/src/store/atom/user.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil'
+
+import { User } from '@models/user'
+
+export const userAtom = atom<User | null>({
+  key: 'auth/user',
+  default: null,
+})

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -11,7 +11,8 @@
       "@constants": ["src/constants/index"],
       "@models/*": ["src/models/*"],
       "@utils/*": ["src/utils/*"],
-      "@hooks/*": ["src/hooks/*"]
+      "@hooks/*": ["src/hooks/*"],
+      "@store/*": ["src/store/*"]
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8195,6 +8195,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hamt_plus@npm:1.0.2":
+  version: 1.0.2
+  resolution: "hamt_plus@npm:1.0.2"
+  checksum: 10c0/c5aa5cc08228e8cc2a90150fef680bd5b09f16a327bdab799daeb80fd3c987663308b14e2c6718abdf75afce21d29607e35f2705eb336a14aa935c0ca5949ce7
+  languageName: node
+  linkType: hard
+
 "handle-thing@npm:^2.0.0":
   version: 2.0.1
   resolution: "handle-thing@npm:2.0.1"
@@ -11638,6 +11645,7 @@ __metadata:
     react-query: "npm:^3.39.3"
     react-router-dom: "npm:^6.27.0"
     react-scripts: "npm:5.0.1"
+    recoil: "npm:^0.7.7"
     swiper: "npm:^11.1.14"
     typescript: "npm:^4.4.2"
     web-vitals: "npm:^2.1.0"
@@ -13172,6 +13180,22 @@ __metadata:
   dependencies:
     picomatch: "npm:^2.2.1"
   checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
+  languageName: node
+  linkType: hard
+
+"recoil@npm:^0.7.7":
+  version: 0.7.7
+  resolution: "recoil@npm:0.7.7"
+  dependencies:
+    hamt_plus: "npm:1.0.2"
+  peerDependencies:
+    react: ">=16.13.1"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: 10c0/630a73b0bdfb1b453c68eca9b3fa0771d489006fbd856a7700174d775978ba3faa10d251ac2af7c07142014dcba07c2b103f448ecc19b6124d3228ec810f5c28
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- firestore에 저장된 user 정보가 있으면 홈 화면으로 이동

- 로그인이 user 정보를 recoil state로 보관 및 전역에서 사용하도록 기능 구현
  - recoil 라이브러리 설치: state를 atom라는 단위로 취급하고, 상태 관리할 atom을 useSetRecoilState 사용하여 recoil에 보관
  - AuthGuard 컴포넌트에서 auth state가 변경되면(onAuthStateChanged) recoil의 정의한 atom에 보관
  - recoilRoot를 최상위(index.tsx)에 감싸고, authgroard를 app 최상위에 감싸도록 정의
  - user 정보를 전역으로 관리하도록 함