### PR TITLE
[feat] 찜하기 기능 구현

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="root-portal"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/components/hotel/ActionButtons.tsx
+++ b/src/components/hotel/ActionButtons.tsx
@@ -6,19 +6,35 @@ import Text from '@shared/Text'
 import Spacing from '@shared/Spacing'
 
 import useShare from '@hooks/useShare'
+import useLike from '@hooks/like/useLike'
 import { Hotel } from '@models/hotel'
 
 function ActionButtons({ hotel }: { hotel: Hotel }) {
   const share = useShare()
-  const { name, comment, mainImageUrl } = hotel
+  const { name, comment, mainImageUrl, id } = hotel
+  const { data: likes, mutate: handleLike } = useLike()
+
+  // list와 가진 data가 맞지 않아서 list를 가져오는 방식으로 사용했지만,
+  // data만 많아지는 경우 단일 data를 select 해오는 방식으로도 최적화 가능
+  const isLike = Boolean(likes?.find((like) => like.hotelId === hotel.id))
 
   return (
     <Flex css={ContainerStyles}>
       <Button
         label="찜하기"
-        iconUrl="https://cdn4.iconfinder.com/data/icons/twitter-29/512/166_Heart_Love_Like_Twitter-512.png"
+        iconUrl={
+          isLike
+            ? 'https://cdn4.iconfinder.com/data/icons/twitter-29/512/166_Heart_Love_Like_Twitter-512.png'
+            : 'https://cdn1.iconfinder.com/data/icons/unicons-line-vol-4/24/heart-alt-512.png'
+        }
         onClick={() => {
-          //ToDo
+          handleLike({
+            hotel: {
+              id,
+              name,
+              mainImageUrl,
+            },
+          })
         }}
       />
       <Button

--- a/src/components/hotelList/HotelItem.tsx
+++ b/src/components/hotelList/HotelItem.tsx
@@ -13,7 +13,19 @@ import addDelimeter from '@utils/addDelimeter'
 import formatTime from '@utils/formatTime'
 
 // interface임을 명시하기 위해 I라는 prefix붙임
-function HotelItem({ hotel }: { hotel: Hotel }) {
+function HotelItem({
+  hotel,
+  isLike,
+  onLike,
+}: {
+  hotel: Hotel
+  isLike: boolean
+  onLike: ({
+    hotel,
+  }: {
+    hotel: Pick<Hotel, 'id' | 'name' | 'mainImageUrl'>
+  }) => void
+}) {
   const [remainedTime, setRemainedTime] = useState(0)
 
   useEffect(() => {
@@ -67,6 +79,18 @@ function HotelItem({ hotel }: { hotel: Hotel }) {
     )
   }
 
+  const handleLike = (e: React.MouseEvent<HTMLImageElement>) => {
+    //heart(찜하기) 버튼 클릭했을 때, 기본 이벤트 동작 방지
+    e.preventDefault()
+    onLike({
+      hotel: {
+        id: hotel.id,
+        name: hotel.name,
+        mainImageUrl: hotel.mainImageUrl,
+      },
+    })
+  }
+
   return (
     <Link to={`/hotel/${hotel.id}`}>
       <div>
@@ -85,7 +109,21 @@ function HotelItem({ hotel }: { hotel: Hotel }) {
             </Flex>
           }
           right={
-            <Flex direction="column" align="flex-end">
+            <Flex
+              direction="column"
+              align="flex-end"
+              style={{ position: 'relative' }}
+            >
+              <img
+                src={
+                  isLike
+                    ? 'https://cdn4.iconfinder.com/data/icons/twitter-29/512/166_Heart_Love_Like_Twitter-512.png'
+                    : 'https://cdn1.iconfinder.com/data/icons/unicons-line-vol-4/24/heart-alt-512.png'
+                }
+                alt=""
+                css={iconHeartStyles}
+                onClick={handleLike}
+              />
               <img src={hotel.mainImageUrl} alt="" css={imageStyle} />
               <Spacing size={8} />
               <Text bold={true}>{addDelimeter(hotel.price)}원</Text>
@@ -108,6 +146,14 @@ const imageStyle = css`
   border-radius: 8px;
   object-fit: cover;
   margin-left: 16px;
+`
+
+const iconHeartStyles = css`
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 30px;
+  height: 30px;
 `
 
 export default HotelItem

--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -14,7 +14,7 @@ function Navbar() {
     ['/signin', '/signup'].includes(location.pathname) === false
 
   const user = useUser()
-  console.log(user)
+
   const renderButton = useCallback(() => {
     if (user != null) {
       //TODO 클릭시 user 정보 페이지로 이동 기능 추가

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,4 +2,5 @@ export const COLLECTIONS = {
   HOTEL: 'HOTEL',
   ROOM: 'ROOM',
   USER: 'USER',
+  LIKE: 'LIKE',
 }

--- a/src/contexts/AlertContext.tsx
+++ b/src/contexts/AlertContext.tsx
@@ -1,0 +1,78 @@
+import {
+  ComponentProps,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import { createPortal } from 'react-dom'
+
+import Alert from '@shared/Alert'
+
+// ComponentProps: component의 prop을 가져오기 위함
+type AlertProps = ComponentProps<typeof Alert>
+// AlertProps에서 open이라는 Prop 제거
+type AlertOptions = Omit<AlertProps, 'open'>
+
+interface AlertContextValue {
+  open: (options: AlertOptions) => void
+}
+
+const Context = createContext<AlertContextValue | undefined>(undefined)
+
+const defaultValue: AlertProps = {
+  open: false,
+  title: null,
+  description: null,
+  onButtonClick: () => {},
+}
+
+export function AlertContextProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [alertState, setAlertState] = useState(defaultValue)
+
+  const $portal_root = document.getElementById('root_portal')
+
+  const close = useCallback(() => {
+    setAlertState(defaultValue)
+  }, [])
+
+  const open = useCallback(({ onButtonClick, ...options }: AlertOptions) => {
+    setAlertState({
+      ...options,
+      // alert이 닫히면서 실행됨: opetion으로 전달받은 onButtonClick 함수 실행, close 클로저 함수도 실행
+      onButtonClick: () => {
+        close()
+        onButtonClick()
+      },
+      open: true,
+    })
+  }, [])
+
+  const values = useMemo(() => ({ open }), [open])
+
+  return (
+    // 자식요소에서 value로 바로 접근할 수 있음
+    <Context.Provider value={values}>
+      {children}
+
+      {$portal_root != null
+        ? createPortal(<Alert {...alertState} />, $portal_root)
+        : null}
+    </Context.Provider>
+  )
+}
+
+export function useAlertContext() {
+  const values = useContext(Context)
+
+  if (values == null) {
+    throw new Error('AlertContext 내부에서 사용해주세요')
+  }
+  return values
+}

--- a/src/hooks/like/useLike.ts
+++ b/src/hooks/like/useLike.ts
@@ -1,0 +1,61 @@
+import { useQuery, useMutation, useQueryClient } from 'react-query'
+import { useNavigate } from 'react-router-dom'
+import useUser from '@hooks/auth/useUser'
+import { getLikes, toggleLike } from '@remote/like'
+import { Hotel } from '@models/hotel'
+import { useAlertContext } from '@contexts/AlertContext'
+
+function useLike() {
+  const user = useUser()
+  const { open } = useAlertContext()
+  const navigate = useNavigate()
+  const client = useQueryClient()
+
+  const { data } = useQuery(
+    ['likes'],
+    () => getLikes({ userId: user?.uid as string }),
+    {
+      enabled: user != null, //user 정보가 있을때만 호출함
+    },
+  )
+
+  const { mutate } = useMutation(
+    ({ hotel }: { hotel: Pick<Hotel, 'id' | 'name' | 'mainImageUrl'> }) => {
+      if (user == null) {
+        throw new Error('로그인필요')
+      }
+
+      return toggleLike({ hotel, userId: user?.uid })
+    },
+    {
+      onSuccess: () => {
+        // data업데이트가 되면 cache된 data를 업데이트
+        client.invalidateQueries(['likes'])
+      },
+      //에러를 처리하는 콜백
+      onError: (e: Error) => {
+        if (e.message === '로그인필요') {
+          open({
+            title: '로그인이 필요한 기능 입니다',
+            onButtonClick: () => {
+              navigate('/signin')
+            },
+          })
+
+          return
+        }
+
+        open({
+          title: '알 수 없는 에러가 발생했습니다. 잠시후 다시 시도해 주세요',
+          onButtonClick: () => {
+            // 다른 액션 필요
+          },
+        })
+      },
+    },
+  )
+
+  return { data, mutate }
+}
+
+export default useLike

--- a/src/hooks/useGoogleSignin.ts
+++ b/src/hooks/useGoogleSignin.ts
@@ -44,7 +44,7 @@ function useGoogleSignin() {
           return
         }
       }
-
+      console.log(error)
       throw new Error('fail to signin')
     }
   }, [navigate])

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import { RecoilRoot } from 'recoil'
 import App from './App'
 import { Global } from '@emotion/react'
 import globalStyles from '@styles/globalStyles'
+import { AlertContextProvider } from '@contexts/AlertContext'
 
 const client = new QueryClient({
   defaultOptions: {
@@ -21,7 +22,9 @@ root.render(
     <Global styles={globalStyles} />
     <RecoilRoot>
       <QueryClientProvider client={client}>
-        <App />
+        <AlertContextProvider>
+          <App />
+        </AlertContextProvider>
       </QueryClientProvider>
     </RecoilRoot>
   </React.StrictMode>,

--- a/src/models/like.ts
+++ b/src/models/like.ts
@@ -1,0 +1,8 @@
+export interface Like {
+  id: string
+  hotelId: string
+  hotelName: string
+  hotelMainImageUrl: string
+  userId: string
+  order: number
+}

--- a/src/pages/HotelList.tsx
+++ b/src/pages/HotelList.tsx
@@ -7,8 +7,11 @@ import HotelItem from '@components/hotelList/HotelItem'
 import Spacing from '@shared/Spacing'
 import Top from '@shared/Top'
 
+import useLike from '@hooks/like/useLike'
+
 function HotelList() {
   const { data: hotels, hasNextPage, loadMore } = useHotels()
+  const { data: likes, mutate: like } = useLike()
 
   return (
     <div>
@@ -23,7 +26,14 @@ function HotelList() {
         <ul>
           {hotels?.map((hotel, idx) => (
             <Fragment key={hotel.id}>
-              <HotelItem hotel={hotel} />
+              <HotelItem
+                hotel={hotel}
+                //find는 객체를 반환하므로 boolean타입을 전달하기 위함
+                isLike={Boolean(
+                  likes?.find((like) => hotel.id === like.hotelId),
+                )}
+                onLike={like}
+              />
               {idx === hotels.length - 1 ? null : (
                 <Spacing
                   size={8}

--- a/src/remote/like.ts
+++ b/src/remote/like.ts
@@ -1,0 +1,113 @@
+import {
+  collection,
+  getDocs,
+  setDoc,
+  query,
+  where,
+  orderBy,
+  limit,
+  doc,
+  deleteDoc,
+  writeBatch,
+} from 'firebase/firestore'
+
+import { store } from '@remote/firebase'
+import { COLLECTIONS } from '@constants'
+import { Like } from '@models/like'
+import { Hotel } from '@models/hotel'
+
+export async function getLikes({ userId }: { userId: string }) {
+  const snapshot = await getDocs(
+    query(
+      collection(store, COLLECTIONS.LIKE),
+      where('userId', '==', userId), //조건 추가
+      orderBy('order', 'asc'), //정렬
+    ),
+  )
+
+  return snapshot.docs.map(
+    (doc) =>
+      ({
+        id: doc.id,
+        ...doc.data(),
+      }) as Like,
+  )
+}
+
+//이미 찜이 되었다면 -> 삭제
+//찜 아니라면 -> 저장(등록)
+export async function toggleLike({
+  hotel,
+  userId,
+}: {
+  hotel: Pick<Hotel, 'id' | 'name' | 'mainImageUrl'>
+  userId: string
+}) {
+  // getDocs - 검색, query - query문 생성, collection - Like Collection 접근, where 조건 추가
+  const findSnapshot = await getDocs(
+    query(
+      collection(store, COLLECTIONS.LIKE),
+      where('userId', '==', userId),
+      where('hotelId', '==', hotel.id),
+    ),
+  )
+
+  //이미 존재함 -> 삭제
+  if (findSnapshot.docs.length > 0) {
+    //1, 2(삭제), 3, 4
+    //[3, 4] data를 가져오고
+    //order값을 -1로 변경 => 2, 3
+    const removeTarget = findSnapshot.docs[0]
+    const removeTargetOrder = removeTarget.data().order
+
+    const updateTargetSnapshot = await getDocs(
+      query(
+        collection(store, COLLECTIONS.LIKE),
+        where('userId', '==', userId),
+        where('order', '>', removeTargetOrder),
+      ),
+    )
+
+    if (updateTargetSnapshot.empty) {
+      deleteDoc(removeTarget.ref)
+    } else {
+      const batch = writeBatch(store)
+
+      const updateData = updateTargetSnapshot.forEach((doc) => {
+        batch.update(doc.ref, { order: doc.data().order - 1 })
+      })
+
+      // 문서 업데이트
+      await batch.commit()
+      // target을 삭제함
+      deleteDoc(removeTarget.ref)
+    }
+  } else {
+    //없음 -> 생성
+    //1. 맨 마지막 Like 정보 가져오기
+    const lastLikeSnapshot = await getDocs(
+      query(
+        collection(store, COLLECTIONS.LIKE),
+        where('userId', '==', userId),
+        orderBy('order', 'desc'),
+        limit(1),
+      ),
+    )
+
+    const lastOrder = lastLikeSnapshot.empty
+      ? 0
+      : lastLikeSnapshot.docs[0].data().order
+
+    const newLike = {
+      hotelId: hotel.id,
+      hotelName: hotel.name,
+      hotelMainImageUrl: hotel.mainImageUrl,
+      userId,
+      order: lastOrder + 1,
+    } as Like
+    query(collection(store, COLLECTIONS.LIKE))
+
+    //2. Like 정보 추가하기
+    await setDoc(doc(collection(store, COLLECTIONS.LIKE)), newLike)
+  }
+}

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -12,7 +12,8 @@
       "@models/*": ["src/models/*"],
       "@utils/*": ["src/utils/*"],
       "@hooks/*": ["src/hooks/*"],
-      "@store/*": ["src/store/*"]
+      "@store/*": ["src/store/*"],
+      "@contexts/*": ["src/contexts/*"]
     }
   }
 }


### PR DESCRIPTION
- 찜한 목록 업데이트 서비스 구현(firebase 이용)
  - 찜한 데이터 저장을 위한 Collection에 Like 추가
  - 찜한 목록을 가져오는 서비스와 toggle state에 따라 찜하기 기능 추가(저장 or 삭제)
  - custom Hook 구현
    - useQuery로 찜한 데이터 가져오도록 함
    - useMutation으로 저장, 삭제 데이터 기능 구현
    - useQueryClient의 invalidateQueries 메서드 이용하여 캐시 데이터를 업데이트 함: 찜한 목록 업데이트
  - Like interface를 추가하여 hotel data와 찜한 순서를 위한 order 데이터 추가
    - insert: 가장 마지막 order의 +1
    - delete: 삭제 데이터의 이후의 order값을 -1로 재조정

- 호텔 목록(HotelList.tsx)과 호텔 상세 - actionbutton(ActionButtons.tsx)에 찜하기 기능 추가