### PR TITLE
[refactor] 로딩 컴포넌트의 hoc로 구현

### DIFF
--- a/src/components/hotel/Rooms.tsx
+++ b/src/components/hotel/Rooms.tsx
@@ -9,6 +9,7 @@ import ListRow from '@shared/ListRow'
 import Tag from '@shared/Tag'
 import Spacing from '@shared/Spacing'
 import Button from '@shared/Button'
+import withSuspense from '@shared/hocs/withSuspense'
 
 import useRooms from './hook/useRooms'
 import addDelimeter from '@utils/addDelimeter'
@@ -120,4 +121,6 @@ const imageStyle = css`
   border-radius: 4px;
 `
 
-export default Rooms
+export default withSuspense(Rooms, {
+  fallback: <div>룸 정보를 가져오는 중...</div>,
+})

--- a/src/components/hotel/hook/useRooms.ts
+++ b/src/components/hotel/hook/useRooms.ts
@@ -34,7 +34,9 @@ function useRooms(hotelId: string) {
   }, [hotelId, client])
 
   //배열 안에는 캐싱 key값
-  return useQuery(['rooms', hotelId], () => getRooms(hotelId))
+  return useQuery(['rooms', hotelId], () => getRooms(hotelId), {
+    suspense: true,
+  })
 }
 
 export default useRooms

--- a/src/components/hotelList/hooks/useHotels.ts
+++ b/src/components/hotelList/hooks/useHotels.ts
@@ -19,6 +19,7 @@ function useHotels() {
       getNextPageParam: (snapshot) => {
         return snapshot.lastVisible
       },
+      suspense: true,
     },
   )
 

--- a/src/components/shared/hocs/withSuspense.tsx
+++ b/src/components/shared/hocs/withSuspense.tsx
@@ -1,0 +1,17 @@
+import { ComponentType, ReactNode, Suspense } from 'react'
+
+function withSuspense<Props = Record<string, never>>(
+  WrappedComponent: ComponentType<Props>,
+  options: { fallback: ReactNode },
+) {
+  return (props: Props) => {
+    return (
+      <Suspense fallback={options.fallback}>
+        <WrappedComponent {...(props as any)} />
+      </Suspense>
+    )
+  }
+}
+
+export default withSuspense
+//withSuspense(<App />, { fallback: <로딩컴포넌트/> })

--- a/src/pages/HotelList.tsx
+++ b/src/pages/HotelList.tsx
@@ -6,6 +6,7 @@ import useHotels from '@components/hotelList/hooks/useHotels'
 import HotelItem from '@components/hotelList/HotelItem'
 import Spacing from '@shared/Spacing'
 import Top from '@shared/Top'
+import withSuspense from '@shared/hocs/withSuspense'
 
 import useLike from '@hooks/like/useLike'
 
@@ -49,4 +50,6 @@ function HotelList() {
   )
 }
 
-export default HotelList
+export default withSuspense(HotelList, {
+  fallback: <div>호텔목록을 가져오고 있습니다..</div>,
+})


### PR DESCRIPTION
- data 로딩시에 컴포넌트에서 skeleton 으로 렌더링을 직접 구현하는 불편함
- hoc을 이용하여 공통 로직을 재사용하는 컴포넌트를 구현(withSuspense.tsx)
  - 로딩 중에는 suspense에 fallback ui을 렌더링
  - 인자로 전달받은 컴포넌트를 wrapping하여 구현